### PR TITLE
Fix the CheckBoxWidget to work properly with required fields

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changelog
 2.0.5 - unreleased
 ------------------
 
+- Fix the CheckBoxWidget to work properly with required fields and
+  return an error that was previously squashed. Added missing unit tests
+  for widget. This should also fix #11449. [rochecompaan]
 
 2.0.4 - 2011-10-06
 ------------------

--- a/plone/app/form/tests/test_widgets.py
+++ b/plone/app/form/tests/test_widgets.py
@@ -36,4 +36,9 @@ def test_suite():
                              setUp=setUp,
                              tearDown=tearDown,
                              optionflags=optionflags),
+        doctest.DocFileSuite('widgets/checkboxwidget.txt',
+                             package='plone.app.form',
+                             setUp=setUp,
+                             tearDown=tearDown,
+                             optionflags=optionflags),
         ])

--- a/plone/app/form/widgets/checkboxwidget.py
+++ b/plone/app/form/widgets/checkboxwidget.py
@@ -12,27 +12,21 @@ class CheckBoxWidget(BaseWidget):
 
     def __init__(self, context, request):
         BaseWidget.__init__(self, context, request)
-        self.required = self.__required = False
-        self.__name = self.name
-        self.name = ""
+        self.required = False
+        self.__required = context.required
         self.label = ""
         self.hint = ""
 
     disabled = False
-
-    def error(self):
-        return ""
 
     def __call__( self ):
         """Render the widget to HTML."""
         value = self._getFormValue()
         html = "<label for='%s'>%s</label>\n" % (self.name , translate(self.context.title, context=self.request))
         if self.__required:
-            html += "<span class='fieldRequired' title='%s'>%s</span>" % (translate(_(u'title_required', default='Required'), context=self.request), translate(_(u'label_required', default='(Required)'), context=self.request))
+            html += "<span class='required' style='color: #f00;' title='%s'>&#x25a0;</span>" % (translate(_(u'title_required', default='Required'), context=self.request))
         if self.context.description:
             html += "<div class='formHelp'>%s</div>" % translate(self.context.description, context=self.request)
-        if super(BaseWidget, self).error() != '':
-            html += "<div>%s</div>" % translate(super(BaseWidget, self).error(), context=self.request)
         
         if value == 'on':
             kw = {'checked': 'checked'}

--- a/plone/app/form/widgets/checkboxwidget.txt
+++ b/plone/app/form/widgets/checkboxwidget.txt
@@ -1,0 +1,105 @@
+CheckBoxWidget
+==============
+
+    >>> from plone.app.form.widgets import CheckBoxWidget
+    >>> from zope.publisher.browser import TestRequest
+    >>> request = TestRequest()
+    >>> from zope.schema import Bool
+    >>> from xml.dom.minidom import parseString
+
+Let's test a non required boolean field first.
+
+    >>> field = Bool(__name__='deletePortrait',
+    ...              title=u'Delete portrait',
+    ...              required=False)
+
+Render the widget and make sure the checkbox is in front of the label.
+
+    >>> widget = CheckBoxWidget(field, request)
+    >>> dom = parseString('<div>%s</div>' % widget())
+    >>> inputs = dom.getElementsByTagName('input')
+    >>> inputs[0].getAttributeNode('name').value
+    u'field.deletePortrait.used'
+    >>> inputs[0].getAttributeNode('class').value
+    u'hiddenType'
+    >>> inputs[0].getAttributeNode('value').value
+    u''
+    >>> inputs[1].getAttributeNode('name').value
+    u'field.deletePortrait'
+    >>> inputs[1].getAttributeNode('class').value
+    u'checkboxType'
+    >>> inputs[1].getAttributeNode('value').value
+    u'on'
+    >>> inputs[1].getAttributeNode('checked') is None
+    True
+    >>> label = inputs[1].nextSibling.nextSibling
+    >>> label.nodeName
+    u'label'
+    >>> label.getAttributeNode('for').value
+    u'field.deletePortrait'
+    >>> label.firstChild.data
+    u'Delete portrait'
+    >>> dom.unlink()
+
+Make sure that there is no error for a non-required boolean field
+
+    >>> request.form['field.deletePortrait.used'] = u''
+    >>> widget.getInputValue()
+    False
+    >>> widget.error()
+    ''
+    >>> request.form['field.deletePortrait'] = 'on'
+    >>> widget.getInputValue()
+    True
+
+Test the rendering of a required field. Note that we need to explicitly
+set the missing_value to False for the field fail validation
+
+    >>> field = Bool(__name__='acceptTerms',
+    ...              title=u'Accept Terms',
+    ...              required=True, missing_value=False)
+    >>> widget = CheckBoxWidget(field, request)
+    >>> dom = parseString('<div>%s</div>' % widget())
+    >>> inputs = dom.getElementsByTagName('input')
+    >>> inputs[0].getAttributeNode('name').value
+    u'field.acceptTerms.used'
+    >>> inputs[0].getAttributeNode('class').value
+    u'hiddenType'
+    >>> inputs[0].getAttributeNode('value').value
+    u''
+    >>> inputs[1].getAttributeNode('name').value
+    u'field.acceptTerms'
+    >>> inputs[1].getAttributeNode('class').value
+    u'checkboxType'
+    >>> inputs[1].getAttributeNode('value').value
+    u'on'
+    >>> inputs[1].getAttributeNode('checked') is None
+    True
+    >>> label = inputs[1].nextSibling.nextSibling
+    >>> label.nodeName
+    u'label'
+    >>> label.getAttributeNode('for').value
+    u'field.acceptTerms'
+    >>> label.firstChild.data
+    u'Accept Terms'
+    >>> spans = dom.getElementsByTagName('span')
+    >>> spans[0].getAttributeNode('class').value
+    u'required'
+    >>> spans[0].getAttributeNode('title').value
+    u'Required'
+    >>> spans[0].firstChild.data
+    u'\u25a0'
+    >>> dom.unlink()
+
+Test for a error when the checbkox is not ticked for a required field.
+
+    >>> request.form['field.acceptTerms.used'] = u''
+    >>> widget.getInputValue()
+    Traceback (most recent call last):
+    WidgetInputError: ('acceptTerms', '', RequiredMissing('acceptTerms'))
+
+Tick the box and make sure we don't get an error anymore
+
+    >>> request.form['field.acceptTerms'] = 'on'
+    >>> widget.getInputValue()
+    True


### PR DESCRIPTION
Fix the CheckBoxWidget to work properly with required fields and return an error that was previously squashed. Added missing unit tests for widget. This should also fix #11449.
