### PR TITLE
Fixed TypeError in DateComponents.resault()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 2.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed TypeError in DateComponents.resault()
+  [yangh]
 
 
 2.2.1 (2013-01-01)

--- a/plone/app/form/widgets/datecomponents.py
+++ b/plone/app/form/widgets/datecomponents.py
@@ -192,6 +192,9 @@ class DateComponents(BrowserView):
             
         minute=int(date.strftime('%M'))
         
+        if minute_step is None:
+            minute_step = 5
+
         if minute + minute_step >= 60:
             # edge case. see doctest for explanation
             minute = 60 - minute_step


### PR DESCRIPTION
Ensure minute_step is not None, Some third eggs (eg. PloneFormGen)
may call DateComponents.resault() with minute_step = None, which
cause an int + None TypeError here.
